### PR TITLE
Stop observeing when refresher is removed from superview

### DIFF
--- a/SpringIndicator/SpringIndicator.swift
+++ b/SpringIndicator/SpringIndicator.swift
@@ -419,6 +419,11 @@ public extension SpringIndicator {
             layoutIfNeeded()
         }
         
+        public override func removeFromSuperview() {
+            removeObserver()
+            super.removeFromSuperview()
+        }
+        
         weak var target: AnyObject?
         public override func addTarget(target: AnyObject?, action: Selector, forControlEvents controlEvents: UIControlEvents) {
             super.addTarget(target, action: action, forControlEvents: controlEvents)


### PR DESCRIPTION
When execute `removeFromSuperview()` to Refresher, app will crash.

## Reproduction

In SpringIndicatorExample, write `refreshControl.removeFromSuperview()` anywhere in TableViewController.

Example:

```
func onRefresh() {
    refreshControl.removeFromSuperview()
    let delay = 2.0 * Double(NSEC_PER_SEC)
    let time  = dispatch_time(DISPATCH_TIME_NOW, Int64(delay))
    dispatch_after(time, dispatch_get_main_queue()) {
        self.refreshControl.endRefreshing()
    }
}
```

And then, show table view and go back to ViewController and the app crashes. It's because observer is still observing nil object.

## Fix

I wrote `removeObserver()` in overrieded `removeFromSuperview()`. By this, observer stop observing nil object.

```
public override func removeFromSuperview() {
    removeObserver()
    super.removeFromSuperview()
}
```

Thanks.