### PR TITLE
Make Refresher's init(frame: CGRect) public

### DIFF
--- a/SpringIndicator/SpringIndicator.swift
+++ b/SpringIndicator/SpringIndicator.swift
@@ -357,7 +357,7 @@ public extension SpringIndicator {
             self.init(frame: CGRect.zero)
         }
         
-        override init(frame: CGRect) {
+        public override init(frame: CGRect) {
             super.init(frame: frame)
             
             setupIndicator()


### PR DESCRIPTION
前は iOS 7対応していたので、ソースを直接プロジェクトに入れてました。でも今は、Cocoapodsを使って、Frameworkとしてビルドされますね。その影響で、public 以外のメソッドが呼べなくなりました。

この init を override して、カスタマイズしているところがあったので、Framework になったタイミングで、使えなくなりました。他の init は public だったから、まあ public でいいだろうと思いました